### PR TITLE
Ruta Entity relativa a vendor no a proyecto

### DIFF
--- a/src/DoctrineBuilder.php
+++ b/src/DoctrineBuilder.php
@@ -40,7 +40,15 @@ class DoctrineBuilder {
                 if(  $directories = $this->configurationLoader->get('doctrine.annotation.paths', false) )
                     $this->setMetadataDirectory($directories);
                 else
-                    $this->setMetadataDirectory(__DIR__. DIRECTORY_SEPARATOR . 'Entity');
+                   /*
+                    * Ruta de Entity relativo a proyecto actual src/DNOISE/Entity
+                    * TODO: Solución global
+                    */ 
+                   $this->setMetadataDirectory(
+                        __DIR__.DIRECTORY_SEPARATOR
+                            .'..'.DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR
+                            .'..'.DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR
+                            .'src'.DIRECTORY_SEPARATOR.'DNOISE'.DIRECTORY_SEPARATOR.'Entity');
 
             $this->configuration = Setup::createAnnotationMetadataConfiguration($this->metadataDirectory, $this->isDevMode, null, null, false );
         }


### PR DESCRIPTION
Un problema que me me ha surgido al instalar el proyecto de BotFollow desde cero en otra máquina.
Cuando corro por primera vez la orden desde consola para crear las entidades sin que estas estuvieran previamente creadas, me devuelve el siguiente error:

`app-console:validate-schema`

```
[Doctrine\Common\Persistence\Mapping\MappingException]
  File mapping drivers must have a valid directory path, however the given path [/mnt/hgfs
  /www/vhosts/botfollow/httpdocs/vendor/phpdnoise/doctrine/src/Entity] seems to be incorre
  ct!
```

`app-console:schema-tool:create`

```
[Doctrine\Common\Persistence\Mapping\MappingException]
  File mapping drivers must have a valid directory path, however the given path [/mnt/hgfs
  /www/vhosts/botfollow/httpdocs/vendor/phpdnoise/doctrine/src/Entity] seems to be incorre
  ct!
```

Para poder continuar temporalmente el desarrollo y evitar este error he parcheado el fallback de la ruta donde debe buscar las Entidades cuando no se han generado nunca _para este proyecto_ a src/DNOISE/Entity
